### PR TITLE
avoid parsing nil value in info

### DIFF
--- a/lib/neocities/cli.rb
+++ b/lib/neocities/cli.rb
@@ -112,7 +112,7 @@ module Neocities
       out = []
 
       resp[:info].each do |k,v|
-        v = Time.parse(v).localtime if k == :created_at || k == :last_updated
+        v = Time.parse(v).localtime if v && (k == :created_at || k == :last_updated)
         out.push [@pastel.bold(k), v]
       end
 


### PR DESCRIPTION
I kept getting this on a new site, presumably because it was never updated.

```ruby
$ neocities info my_site
/Users/me/.rbenv/versions/2.4.4/lib/ruby/2.4.0/time.rb:367:in `_parse': no implicit conversion of nil into String (TypeError)
    from /Users/me/.rbenv/versions/2.4.4/lib/ruby/2.4.0/time.rb:367:in `parse'
    from /Users/me/.rbenv/versions/2.4.4/lib/ruby/gems/2.4.0/gems/neocities-0.0.9/lib/neocities/cli.rb:115:in `block in info'
    from /Users/me/.rbenv/versions/2.4.4/lib/ruby/gems/2.4.0/gems/neocities-0.0.9/lib/neocities/cli.rb:114:in `each'
    from /Users/me/.rbenv/versions/2.4.4/lib/ruby/gems/2.4.0/gems/neocities-0.0.9/lib/neocities/cli.rb:114:in `info'
    from /Users/me/.rbenv/versions/2.4.4/lib/ruby/gems/2.4.0/gems/neocities-0.0.9/lib/neocities/cli.rb:77:in `run'
    from /Users/me/.rbenv/versions/2.4.4/lib/ruby/gems/2.4.0/gems/neocities-0.0.9/bin/neocities:4:in `<top (required)>'
    from /Users/me/.rbenv/versions/2.4.4/bin/neocities:23:in `load'
    from /Users/me/.rbenv/versions/2.4.4/bin/neocities:23:in `<main>'
```

Happened on ruby 2.3, 2.4 and 2.5.

This PR avoids invoking `Time.parse` when `v` is `nil`.