### PR TITLE
Add a dry run option to 'neocities push'.

### DIFF
--- a/lib/neocities/cli.rb
+++ b/lib/neocities/cli.rb
@@ -161,14 +161,20 @@ module Neocities
     def push
       @no_gitignore = false
       @excluded_files = []
+      @dry_run = false
       loop {
         case @subargs[0]
         when '--no-gitignore' then @subargs.shift; @no_gitignore = true
         when '-e' then @subargs.shift; @excluded_files.push(@subargs.shift)
+        when '--dry-run' then @subargs.shift; @dry_run = true
         when /^-/ then puts(@pastel.red.bold("Unknown option: #{@subargs[0].inspect}")); display_push_help_and_exit
         else break
         end
       }
+
+      if @dry_run
+        puts @pastel.green.bold("Doing a dry run, not actually pushing anything")
+      end
 
       root_path = Pathname @subargs[0]
 
@@ -215,7 +221,7 @@ module Neocities
         paths.each do |path|
           next if path.directory?
           print @pastel.bold("Uploading #{path} ... ")
-          resp = @client.upload path, path
+          resp = @client.upload path, path, @dry_run
 
           if resp[:result] == 'error' && resp[:error_type] == 'file_exists'
             print @pastel.yellow.bold("EXISTS") + "\n"
@@ -332,6 +338,8 @@ HERE
   #{@pastel.green '$ neocities push -e node_modules -e secret.txt .'}   Exclude certain files from push
 
   #{@pastel.green '$ neocities push --no-gitignore .'}                  Don't use .gitignore to exclude files
+
+  #{@pastel.green '$ neocities push --dry-run .'}                       Just show what would be uploaded
 
 HERE
       exit

--- a/lib/neocities/client.rb
+++ b/lib/neocities/client.rb
@@ -42,7 +42,7 @@ module Neocities
       post 'upload_hash', remote_path => sha1_hash
     end
 
-    def upload(path, remote_path=nil)
+    def upload(path, remote_path=nil, dry_run=false)
       path = Pathname path
 
       unless path.exist?
@@ -56,8 +56,12 @@ module Neocities
       if res[:files] && res[:files][remote_path.to_s.to_sym] == true
         return {result: 'error', error_type: 'file_exists', message: 'file already exists and matches local file, not uploading'}
       else
-        File.open(path.to_s) do |file|
-          post 'upload', rpath => file
+        if dry_run
+          return {result: 'success'}
+        else
+          File.open(path.to_s) do |file|
+            post 'upload', rpath => file
+          end
         end
       end
     end


### PR DESCRIPTION
When messing up with pages (or static site generator setup), it can be easy to forget you made a bigger change than you wanted to push.

With this option one can see what would be uploaded without actually uploading it:

```
neocities push --dry-run .
```