### PR TITLE
Fix a crash if a gitignore line contains no white-space characters

### DIFF
--- a/lib/neocities/cli.rb
+++ b/lib/neocities/cli.rb
@@ -188,7 +188,8 @@ module Neocities
         if @no_gitignore == false
           begin
             ignores = File.readlines('.gitignore').collect! do |ignore|
-              File.directory?(ignore.strip!) ? "#{ignore}**" : ignore
+              ignore.strip!
+              File.directory?(ignore) ? "#{ignore}**" : ignore
             end
             paths.select! do |path|
               res = true


### PR DESCRIPTION
I encountered this by not putting a newline at the end of the last line of my gitignore.

I suspect the problem is straight forward enough for someone who knows Ruby but here is what the error was, just in case:

`neocities-0.0.13/lib/neocities/cli.rb:191:in `directory?': no implicit conversion of nil into String (TypeError)`

I don't know Ruby but looking up [the docs seemed to clear up the issue for me.](https://ruby-doc.org/core-2.7.0/String.html#method-i-strip-21)