### PR TITLE
Fix undefined `Gem::Command` error

### DIFF
--- a/ext/mkrf_conf.rb
+++ b/ext/mkrf_conf.rb
@@ -1,5 +1,6 @@
 require 'rubygems'
-require 'rubygems/dependency_installer.rb'
+require 'rubygems/command'
+require 'rubygems/dependency_installer'
 begin
   Gem::Command.build_args = ARGV
   rescue NoMethodError


### PR DESCRIPTION
Fixes this error on newer versions of Rubygems:

```console
% gem install --no-document neocities
Successfully installed tty-screen-0.6.5
Successfully installed unicode_utils-1.4.0
Successfully installed unicode-display_width-1.8.0
Successfully installed strings-ansi-0.2.0
Successfully installed strings-0.1.8
Successfully installed tty-color-0.4.3
Successfully installed equatable-0.5.0
Successfully installed pastel-0.7.2
Successfully installed necromancer-0.4.0
Successfully installed tty-table-0.10.0
Successfully installed wisper-1.6.1
Successfully installed tty-cursor-0.4.0
Successfully installed tty-prompt-0.12.0
Successfully installed rake-12.3.3
Successfully installed httpclient-2.8.3
Building native extensions. This could take a while...
ERROR:  Error installing neocities:
	ERROR: Failed to build gem native extension.

    current directory: /usr/local/bundle/gems/neocities-0.0.15/ext
/usr/local/bin/ruby mkrf_conf.rb
mkrf_conf.rb:4:in `<main>': uninitialized constant Gem::Command (NameError)
```