### PR TITLE
Add DOTMATCH flag to include hidden dotfiles

### DIFF
--- a/lib/neocities/cli.rb
+++ b/lib/neocities/cli.rb
@@ -213,7 +213,7 @@ module Neocities
       end
 
       Dir.chdir(root_path) do
-        paths = Dir.glob(File.join('**', '*'))
+        paths = Dir.glob(File.join('**', '*'), File::FNM_DOTMATCH)
 
         if @no_gitignore == false
           begin


### PR DESCRIPTION
This change adds the DOTMATCH flag to the glob function, as suggested in https://github.com/neocities/neocities-ruby/issues/16