### PR TITLE
Strip api key whitespace to ease configuration

### DIFF
--- a/lib/neocities/cli.rb
+++ b/lib/neocities/cli.rb
@@ -48,6 +48,8 @@ module Neocities
       if !@api_key
         begin
           @api_key = File.read @app_config_path
+          # Remove any trailing whitespace causing HTTP requests to fail
+          @api_key = @api_key.strip
         rescue Errno::ENOENT
           @api_key = nil
         end


### PR DESCRIPTION
Fixes #21 by trimming whitespace from the API key.

## Testing instructions for Linux

To reproduce the bug:
1. Confirm your existing API key works by trying `neocities push` and confirming it can check that files exist/push new files.
2. Add `\r` to the end of `~/.config/neocities/config`:
```sh
$ cd ~/.config/neocities
$ cp config config.bak
# Trailing \r is added by vim and other editors automatically, so is a common configuration issue when juggling multiple site keys
$ echo "$(cat config)\r" > config
```
3. Now try `neocities push` again, and you should encounter the error from the linked issue.

To test that this PR works, keep the new `config` file with `\r` at the end, checkout this branch, and run `./bin/neocities push` and confirm that the CLI now works with the trailing whitespace.