### PR TITLE
'neocities pull' - allow users to pull their sites files

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,2 +1,6 @@
 source 'https://rubygems.org'
 gemspec
+
+# cursor whirlies (for loading)
+gem 'whirly'
+gem 'paint'

--- a/lib/neocities/cli.rb
+++ b/lib/neocities/cli.rb
@@ -314,7 +314,16 @@ module Neocities
 
     def pull
       begin
-        quiet = !(['--log', '-l'].include? @subargs[0])
+        # default options
+        quiet = true
+
+        loop {
+          case @subargs[0]
+          when '--logs', '-l' then @subargs.shift; quiet = false
+          when /^-/ then puts(@pastel.red.bold("Unknown option: #{@subargs[0].inspect}")); display_pull_help_and_exit
+          else break
+          end
+        }
 
         file = File.read @app_config_path
         data = JSON.load file
@@ -323,6 +332,7 @@ module Neocities
         last_pull_loc = data["LAST_PULL"] ? data["LAST_PULL"]["loc"] : nil
 
         Whirly.start spinner: ["😺", "😸", "😹", "😻", "😼", "😽", "🙀", "😿", "😾"], status: "Retrieving files for #{@pastel.bold @sitename}" if quiet
+
         resp = @client.pull @sitename, last_pull_time, last_pull_loc, quiet
 
         # write last pull data to file (not necessarily the best way to do this, but better than cloning every time)
@@ -402,7 +412,13 @@ HERE
       display_banner
 
       puts <<HERE
-  #{@pastel.magenta.bold 'UNDER PRESSURe'}
+  #{@pastel.green.bold 'pull'} - Get the most recent version of files from your site
+
+  #{@pastel.dim 'Examples:'}
+
+  #{@pastel.green '$ neocities pull'}        Download/update files in the current folder
+
+  #{@pastel.green '$ neocities pull --logs'} Download/update files in the current folder, displaying information about each download
 
 HERE
       exit

--- a/lib/neocities/cli.rb
+++ b/lib/neocities/cli.rb
@@ -3,11 +3,14 @@ require 'pastel'
 require 'tty/table'
 require 'tty/prompt'
 require 'fileutils'
+require 'json' # for reading configs
+require 'whirly' # for loader spinner
+
 require File.join(File.dirname(__FILE__), 'client')
 
 module Neocities
   class CLI
-    SUBCOMMANDS = %w{upload delete list info push logout pizza}
+    SUBCOMMANDS = %w{upload delete list info push logout pizza pull}
     HELP_SUBCOMMANDS = ['-h', '--help', 'help']
     PENELOPE_MOUTHS = %w{^ o ~ - v U}
     PENELOPE_EYES = %w{o ~ O}
@@ -19,7 +22,7 @@ module Neocities
       @subargs = @argv[1..@argv.length]
       @prompt = TTY::Prompt.new
       @api_key = ENV['NEOCITIES_API_KEY'] || nil
-      @app_config_path = File.join self.class.app_config_path('neocities'), 'config'
+      @app_config_path = File.join self.class.app_config_path('neocities'), 'config.json' # added json extension
     end
 
     def display_response(resp)
@@ -43,13 +46,21 @@ module Neocities
       end
 
       display_help_and_exit if @subcmd.nil? || @argv.include?(HELP_SUBCOMMANDS) || !SUBCOMMANDS.include?(@subcmd)
-      send "display_#{@subcmd}_help_and_exit" if @subargs.empty?
+
+      if @subcmd != "pull"
+        send "display_#{@subcmd}_help_and_exit" if @subargs.empty?
+      end
 
       if !@api_key
         begin
-          @api_key = File.read @app_config_path
-          # Remove any trailing whitespace causing HTTP requests to fail
-          @api_key = @api_key.strip
+          file = File.read @app_config_path
+          data = JSON.load file
+          
+          if data
+            @api_key = data["API_KEY"].strip # Remove any trailing whitespace causing HTTP requests to fail
+            @sitename = data["SITENAME"] # Store the sitename to be able to reference it later
+            @last_pull = data["LAST_PULL"] # Store the last time a pull was performed so that we only fetch from updated files
+          end
         rescue Errno::ENOENT
           @api_key = nil
         end
@@ -67,8 +78,14 @@ module Neocities
 
         resp = @client.key
         if resp[:api_key]
+          conf = {
+            "API_KEY": resp[:api_key],
+            "SITENAME": @sitename,
+          }
+
           FileUtils.mkdir_p Pathname(@app_config_path).dirname
-          File.write @app_config_path, resp[:api_key]
+          File.write @app_config_path, conf.to_json
+
           puts "The api key for #{@pastel.bold @sitename} has been stored in #{@pastel.bold @app_config_path}."
         else
           display_response resp
@@ -295,6 +312,35 @@ module Neocities
       end
     end
 
+    def pull
+      begin
+        quiet = !(['--log', '-l'].include? @subargs[0])
+
+        file = File.read @app_config_path
+        data = JSON.load file
+
+        last_pull_time = data["LAST_PULL"] ? data["LAST_PULL"]["time"] : nil
+        last_pull_loc = data["LAST_PULL"] ? data["LAST_PULL"]["loc"] : nil
+
+        Whirly.start spinner: ["😺", "😸", "😹", "😻", "😼", "😽", "🙀", "😿", "😾"], status: "Retrieving files for #{@pastel.bold @sitename}" if quiet
+        resp = @client.pull @sitename, last_pull_time, last_pull_loc, quiet
+
+        # write last pull data to file (not necessarily the best way to do this, but better than cloning every time)
+        data["LAST_PULL"] = {
+          "time": Time.now,
+          "loc": Dir.pwd
+        }
+
+        File.write @app_config_path, data.to_json
+      rescue StandardError => ex
+        Whirly.stop if quiet
+        puts @pastel.red.bold "\nA fatal error occurred :-("
+        puts @pastel.red ex
+      ensure
+        exit
+      end
+    end
+
     def display_pizza_help_and_exit
       puts "Sorry, we're fresh out of dough today. Try again tomorrow."
       exit
@@ -351,6 +397,17 @@ HERE
 HERE
       exit
     end
+
+    def display_pull_help_and_exit
+      display_banner
+
+      puts <<HERE
+  #{@pastel.magenta.bold 'UNDER PRESSURe'}
+
+HERE
+      exit
+    end
+
 
     def display_push_help_and_exit
       display_banner
@@ -423,6 +480,7 @@ HERE
     info        Information and stats for your site
     logout      Remove the site api key from the config
     version     Unceremoniously display version and self destruct
+    pull        Get the most recent version of files from your site
     pizza       Order a free pizza
 
 HERE

--- a/lib/neocities/client.rb
+++ b/lib/neocities/client.rb
@@ -52,16 +52,22 @@ module Neocities
         domain = "https://#{sitename}.neocities.org/"
       end
 
+      # start stats
       success_loaded = 0
       start_time = Time.now
       curr_dir = Dir.pwd
 
+      # get list of files
       resp = get 'list'
 
+      if resp[:result] == 'error'
+        raise ArgumentError, resp[:message]
+      end
+      
+      # fetch each file
       resp[:files].each do |file|
         if !file[:is_directory]
           print @pastel.bold("Loading #{file[:path]} ... ") if !quiet
-
           
           if 
             last_pull_time && \
@@ -76,8 +82,6 @@ module Neocities
           
           pathtotry = domain + file[:path]
           fileconts = @http.get pathtotry
-
-          
           
           # follow redirects
           while fileconts.status == 301

--- a/lib/neocities/client.rb
+++ b/lib/neocities/client.rb
@@ -8,6 +8,10 @@ require 'pathname'
 require 'uri'
 require 'digest'
 require 'httpclient'
+require 'pastel'
+require 'date'
+
+require 'whirly'
 
 module Neocities
   class Client
@@ -17,6 +21,7 @@ module Neocities
       @uri = URI.parse API_URI
       @http = HTTPClient.new force_basic_auth: true
       @opts = opts
+      @pastel = Pastel.new eachline: "\n"
 
       unless opts[:api_key] || (opts[:sitename] && opts[:password])
         raise ArgumentError, 'client requires a login (sitename/password) or an api_key'
@@ -27,11 +32,85 @@ module Neocities
       else
         @http.set_auth API_URI, opts[:sitename], opts[:password]
       end
-
     end
 
     def list(path=nil)
       get 'list', :path => path
+    end
+
+    def pull(sitename, last_pull_time=nil, last_pull_loc=nil, quiet=true)
+      site_info = get 'info', sitename: sitename
+
+      if site_info[:result] == 'error'
+        raise ArgumentError, site_info[:message]
+      end
+
+      # handle custom domains for supporter accounts
+      if site_info[:info][:domain] && site_info[:info][:domain] != ""
+        domain = "https://#{site_info[:info][:domain]}/"
+      else
+        domain = "https://#{sitename}.neocities.org/"
+      end
+
+      success_loaded = 0
+      start_time = Time.now
+      curr_dir = Dir.pwd
+
+      resp = get 'list'
+
+      resp[:files].each do |file|
+        if !file[:is_directory]
+          print @pastel.bold("Loading #{file[:path]} ... ") if !quiet
+
+          
+          if 
+            last_pull_time && \
+            last_pull_loc && \
+            Time.parse(file[:updated_at]) <= Time.parse(last_pull_time) && \
+            last_pull_loc == curr_dir && \
+            File.exist?(file[:path]) # case when user deletes file
+            # case when file hasn't been updated since last 
+            print "#{@pastel.yellow.bold "NO NEW UPDATES"}\n" if !quiet
+            next
+          end
+          
+          pathtotry = domain + file[:path]
+          fileconts = @http.get pathtotry
+
+          
+          
+          # follow redirects
+          while fileconts.status == 301
+            new_path = fileconts.header['location'][0]
+            print "\n#{@pastel.red "Fetch from #{pathtotry} failed."}\nTrying #{new_path} instead..." if !quiet
+
+            pathtotry = new_path
+            fileconts = @http.get pathtotry
+          end
+
+          if fileconts.ok?
+            print "#{@pastel.green.bold 'SUCCESS'}\n" if !quiet
+            success_loaded += 1
+
+            File.open("#{file[:path]}", "w") do |f|
+              f.write(fileconts.body)
+            end
+          else
+            print "#{@pastel.red.bold 'FAIL'}\n" if !quiet
+          end
+        else
+          FileUtils.mkdir_p "#{file[:path]}"
+        end
+      end
+
+      # calculate time command took
+      total_time = Time.now - start_time
+
+      # stop the spinner, if there is one
+      Whirly.stop if quiet
+
+      # display stats
+      puts @pastel.green "\nSuccessfully fetched #{success_loaded} files in #{total_time} seconds"
     end
 
     def key
@@ -86,6 +165,7 @@ module Neocities
       uri = @uri+path
       uri.query = URI.encode_www_form params
       resp = @http.get uri
+      
       JSON.parse resp.body, symbolize_names: true
     end
 


### PR DESCRIPTION
This change allows the user to pull their own site's files onto their computer, as suggested in https://github.com/neocities/neocities-ruby/issues/5.  (I think it's important to note that users can only pull files from the website that they've signed in with through the cli)