### PR TITLE
Add whirly to gemspec

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,3 @@
 source 'https://rubygems.org'
-gemspec
 
-# cursor whirlies (for loading)
-gem 'whirly'
-gem 'paint'
+gemspec

--- a/neocities.gemspec
+++ b/neocities.gemspec
@@ -21,5 +21,6 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'tty-prompt',          '~> 0.12', '= 0.12.0'
   spec.add_dependency 'pastel',              '~> 0.7',  '= 0.7.2'
   spec.add_dependency 'httpclient-fixcerts', '~> 2.8',  '>= 2.8.5'
-  spec.add_dependency 'rake',                '~> 12.3',  '>= 12.3.1'
+  spec.add_dependency 'rake',                '~> 12.3', '>= 12.3.1'
+  spec.add_dependency 'whirly',              '~> 0.3',  '>= 0.3.0'
 end


### PR DESCRIPTION
Follow-up for #49
Closes #50

I can confirm I also encountered the bug reported in #50 when working on my previous PR

This does also fully remove the `paint` dependency but I cannot tell what that dependency does. If it needs to be re-added, I'm happy to add it to the gemspec.