### PR TITLE
Handle special characters on pull

### DIFF
--- a/lib/neocities/client.rb
+++ b/lib/neocities/client.rb
@@ -65,6 +65,7 @@ module Neocities
       end
       
       # fetch each file
+      uri_parser = URI::Parser.new
       resp[:files].each do |file|
         if !file[:is_directory]
           print @pastel.bold("Loading #{file[:path]} ... ") if !quiet
@@ -80,7 +81,7 @@ module Neocities
             next
           end
           
-          pathtotry = domain + file[:path]
+          pathtotry = uri_parser.escape(domain + file[:path])
           fileconts = @http.get pathtotry
           
           # follow redirects


### PR DESCRIPTION
Was testing out `pull` when testing my whirly dependency PR and discovered that it doesn't handle spaces in file names correctly. This PR resolves that.

Example error (with site name redacted):

```
$ neocities pull
😿  Retrieving files for my-site                               

A fatal error occurred :-(
bad URI(is not URI?): "https://my-site.neocities.org/file with space.html"
```

As far as I can tell, there is no escaping in the `list` endpoint in the API:
- https://github.com/neocities/neocities/blob/0531a1d85fd2b0d7b1fa333669230f867dd83f89/models/site.rb#L1236-L1264
- https://github.com/neocities/neocities/blob/0531a1d85fd2b0d7b1fa333669230f867dd83f89/app/api.rb#L18-L43