### PR TITLE
Add `mutex_m` to gemspec

### DIFF
--- a/neocities.gemspec
+++ b/neocities.gemspec
@@ -23,4 +23,5 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'httpclient-fixcerts', '~> 2.8',  '>= 2.8.5'
   spec.add_dependency 'rake',                '~> 12.3', '>= 12.3.1'
   spec.add_dependency 'whirly',              '~> 0.3',  '>= 0.3.0'
+  spec.add_dependency 'mutex_m',             '~> 0.3.0','>= 0.3.0'
 end


### PR DESCRIPTION
Starting in Ruby 3.4.0, `mutex_m` is not one of the default gems, but the `neocities` gem requires it.

Fixes #57