### PR TITLE
fix gem's incompability with ruby 3.4+

### DIFF
--- a/neocities.gemspec
+++ b/neocities.gemspec
@@ -24,4 +24,5 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'http',                '~> 5.3',  '>= 5.3.1'
   spec.add_dependency 'rake',                '~> 13',   '>= 13.3.0'
   spec.add_dependency 'whirly',              '~> 0.3',  '>= 0.3.0'
+  spec.add_dependency 'openssl',             '~> 3.3',  '>= 3.3.1'
 end


### PR DESCRIPTION
Hello, at the modern rubies i am getting SSL errors using that gem.

```

/home/o200/.local/share/mise/installs/ruby/3.4.6/lib/ruby/gems/3.4.0/gems/http-5.3.1/lib/http/timeout/null.rb:22:in 'OpenSSL::SSL::SSLSocket#connect': SSL_connect returned=1 errno=0 peeraddr=23.143.32.4:443 state=error: certificate verify failed (unable to get certificate CRL) (OpenSSL::SSL::SSLError)
        from /home/o200/.local/share/mise/installs/ruby/3.4.6/lib/ruby/gems/3.4.0/gems/http-5.3.1/lib/http/timeout/null.rb:22:in 'HTTP::Timeout::Null#connect_ssl'
        from /home/o200/.local/share/mise/installs/ruby/3.4.6/lib/ruby/gems/3.4.0/gems/http-5.3.1/lib/http/timeout/null.rb:39:in 'HTTP::Timeout::Null#start_tls'
        from /home/o200/.local/share/mise/installs/ruby/3.4.6/lib/ruby/gems/3.4.0/gems/http-5.3.1/lib/http/connection.rb:170:in 'HTTP::Connection#start_tls'
        from /home/o200/.local/share/mise/installs/ruby/3.4.6/lib/ruby/gems/3.4.0/gems/http-5.3.1/lib/http/connection.rb:45:in 'HTTP::Connection#initialize'
        from /home/o200/.local/share/mise/installs/ruby/3.4.6/lib/ruby/gems/3.4.0/gems/http-5.3.1/lib/http/client.rb:70:in 'Class#new'
        from /home/o200/.local/share/mise/installs/ruby/3.4.6/lib/ruby/gems/3.4.0/gems/http-5.3.1/lib/http/client.rb:70:in 'HTTP::Client#perform'
        from /home/o200/.local/share/mise/installs/ruby/3.4.6/lib/ruby/gems/3.4.0/gems/http-5.3.1/lib/http/client.rb:31:in 'HTTP::Client#request'
        from /home/o200/.local/share/mise/installs/ruby/3.4.6/lib/ruby/gems/3.4.0/gems/http-5.3.1/lib/http/chainable.rb:21:in 'HTTP::Chainable#get'
        from /home/o200/Projects/neocities-ruby/lib/neocities/client.rb:161:in 'Neocities::Client#get'
        from /home/o200/Projects/neocities-ruby/lib/neocities/client.rb:155:in 'Neocities::Client#info'
        from /home/o200/Projects/neocities-ruby/lib/neocities/cli.rb:131:in 'Neocities::CLI#info'
        from /home/o200/Projects/neocities-ruby/lib/neocities/cli.rb:100:in 'Neocities::CLI#run'
        from ./bin/neocities:4:in '<main>'
```

        
After debugging session ive got a reason why its happened - that's because my rubies uses default openssl 3.3.0. Switching to openssl 3.3.1 fixed this error.

I am relied of this [message](https://github.com/httprb/http/issues/818#issuecomment-3474813594) to see whats wrong with that.