### PR TITLE
added file uploading with their content

### DIFF
--- a/lib/neocities/cli.rb
+++ b/lib/neocities/cli.rb
@@ -309,16 +309,23 @@ module Neocities
           next
         end
 
-        if path.directory?
-          puts "#{path} is a directory, skipping (see the push command)"
-          next
+        if path.file?
+          files_to_upload = [path]
+          remote_paths = [['/', @dir, path.basename.to_s].join('/').gsub(%r{/+}, '/')]
+        else # directory
+          files_to_upload = path.glob("**/*").select(&:file?)
+          remote_paths = files_to_upload.map { |file| ['/', @dir, file.to_s].join('/').gsub(%r{/+}, '/') }
         end
+        
+        files_to_upload.count.times do |file_number|
+          file = files_to_upload[file_number]
+          remote_path = remote_paths[file_number]
 
-        remote_path = ['/', @dir, path.basename.to_s].join('/').gsub %r{/+}, '/'
+          puts @pastel.bold("Uploading #{file} to #{remote_path} ...")
 
-        puts @pastel.bold("Uploading #{path} to #{remote_path} ...")
-        resp = @client.upload path, remote_path
-        display_response resp
+          resp = @client.upload(file, remote_path)
+          display_response resp
+        end
       end
     end
 

--- a/lib/neocities/cli.rb
+++ b/lib/neocities/cli.rb
@@ -491,6 +491,10 @@ HERE
   #{@pastel.green '$ neocities upload img.jpg img2.jpg'}    Upload images to the root of your site
 
   #{@pastel.green '$ neocities upload -d images img.jpg'}   Upload img.jpg to the 'images' directory on your site
+  
+  #{@pastel.green '$ neocities upload cats/'}               Upload 'cats' folder on your site
+  
+  #{@pastel.green '$ neocities upload -d images cats/'}     Upload 'cats' folder to the 'images' directory on your site (it will be cats/images/<your files>)
 
 HERE
       exit
@@ -571,7 +575,7 @@ HERE
       puts <<HERE
   #{@pastel.dim 'Subcommands:'}
     push        Recursively upload a local directory to your site
-    upload      Upload individual files to your Neocities site
+    upload      Upload specific files/directories to your Neocities site
     delete      Delete files from your Neocities site
     list        List files from your Neocities site
     info        Information and stats for your site


### PR DESCRIPTION
Added folder uploading into neocities with folder's content 
My pull request closes the request #71

i don't decided to touch `push` method just because it already complicated plus currently it main purpose is uploading all entire project. I just dont want to make it dirty.

Added functionality is - 
```bash
# Upload 'cats' folder on your site
$ neocities upload cats/

# Upload 'cats' folder to the 'images' directory
$ neocities upload -d images cats/' 
```